### PR TITLE
BUG: When Slicer quit, disconnecting from layoutManager was called ev…

### DIFF
--- a/SlicerProstate/SlicerProstateUtils/buttons.py
+++ b/SlicerProstate/SlicerProstateUtils/buttons.py
@@ -90,7 +90,8 @@ class LayoutButton(BasicIconButton):
 
   def onAboutToBeDestroyed(self, obj):
     super(LayoutButton, self).onAboutToBeDestroyed(obj)
-    self.layoutManager.layoutChanged.disconnect(self.onLayoutChanged)
+    if self.layoutManager:
+      self.layoutManager.layoutChanged.disconnect(self.onLayoutChanged)
 
   def onLayoutChanged(self, layout):
     self.checked = self.LAYOUT == layout


### PR DESCRIPTION
…en when layoutManager was already deleted.
