### PR TITLE
decorators, centroid from label

### DIFF
--- a/SlicerProstate/CMakeLists.txt
+++ b/SlicerProstate/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MODULE_PYTHON_RESOURCES
   Resources/Icons/icon-star-filled.png
   Resources/Icons/icon-star-unfilled.png
   Resources/Icons/LayoutFourUpView.png
+  Resources/Icons/LayoutFourUpTableView.png
   Resources/Icons/LayoutOneUpRedSliceView.png
   Resources/Icons/LayoutSideBySideView.png
   Resources/Icons/SlicesCrosshair.png

--- a/SlicerProstate/SlicerProstateUtils/buttons.py
+++ b/SlicerProstate/SlicerProstateUtils/buttons.py
@@ -2,6 +2,7 @@ import qt, vtk, slicer
 import inspect, os, sys
 from events import SlicerProstateEvents
 from mixins import ParameterNodeObservationMixin
+from decorators import logmethod
 
 
 class BasicIconButton(qt.QPushButton):
@@ -82,6 +83,7 @@ class LayoutButton(BasicIconButton):
     self.checkable = True
     if not self.LAYOUT:
       raise NotImplementedError("Member variable LAYOUT needs to be defined by all deriving classes")
+    self.onLayoutChanged(self.layoutManager.layout)
 
   def _connectSignals(self):
     super(LayoutButton, self)._connectSignals()
@@ -97,8 +99,10 @@ class LayoutButton(BasicIconButton):
     self.checked = self.LAYOUT == layout
 
   def onToggled(self, checked):
-    if checked and self.LAYOUT is not None:
+    if checked and self.layoutManager.layout != self.LAYOUT:
       self.layoutManager.setLayout(self.LAYOUT)
+    if not checked and self.LAYOUT == self.layoutManager.layout:
+      self.onLayoutChanged(self.LAYOUT)
 
 
 class RedSliceLayoutButton(LayoutButton):
@@ -118,7 +122,17 @@ class FourUpLayoutButton(LayoutButton):
 
   def __init__(self, title="", parent=None, **kwargs):
     super(FourUpLayoutButton, self).__init__(title, parent, **kwargs)
-    self.toolTip = "FourUp Layout"
+    self.toolTip = "Four-Up Layout"
+
+
+class FourUpTableViewLayoutButton(LayoutButton):
+
+  FILE_NAME = 'LayoutFourUpTableView.png'
+  LAYOUT = slicer.vtkMRMLLayoutNode.SlicerLayoutFourUpTableView
+
+  def __init__(self, title="", parent=None, **kwargs):
+    super(FourUpTableViewLayoutButton, self).__init__(title, parent, **kwargs)
+    self.toolTip = "Four-Up Table Layout"
 
 
 class SideBySideLayoutButton(LayoutButton):

--- a/SlicerProstate/SlicerProstateUtils/decorators.py
+++ b/SlicerProstate/SlicerProstateUtils/decorators.py
@@ -1,34 +1,40 @@
 from functools import wraps
+import itertools
 import logging
 import inspect
 import slicer
 
 
-def logmethod(level=logging.DEBUG):
+class logmethod(object):
   """ This decorator can used for logging methods without the need of reimplementing log messages again and again. The
-      decorator logs information about the called method name including caller and arguments
+        decorator logs information about the called method name including caller and arguments
 
-    Usage:
+      Usage:
 
-    @logmethod()
-    def sub(x,y, switch=False):
-      return x -y if not switch else y-x
+      @logmethod()
+      def sub(x,y, switch=False):
+        return x -y if not switch else y-x
 
-    @logmethod(level=logging.INFO)
-    def sub(x,y, switch=False):
-      return x -y if not switch else y-x
+      @logmethod(level=logging.INFO)
+      def sub(x,y, switch=False):
+        return x -y if not switch else y-x
   """
 
-  def decorator(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
+  def __init__(self, level=logging.DEBUG):
+    self.logLevel = level
+
+  def __call__(self, func):
+    def wrapped_f(*args, **kwargs):
       args_map = {}
-      if args or kwargs:
-        args_map = inspect.getcallargs(func, *args, **kwargs)
+      try:
+        if args or kwargs:
+          args_map = inspect.getcallargs(func, *args, **kwargs)
+      except TypeError:
+        pass
       className = ""
       if 'self' in args_map:
         cls = args_map['self'].__class__
-        className = cls.__name__+'.'
+        className = cls.__name__ + '.'
       try:
         callerMethod = inspect.stack()[1][0].f_code.co_name
         callerClass = inspect.stack()[1][0].f_locals["self"].__class__.__name__
@@ -38,12 +44,10 @@ def logmethod(level=logging.DEBUG):
       caller = ""
       if callerClass != "" and callerMethod != "":
         caller = " from {}.{}".format(callerClass, callerMethod)
-      logging.log(level, "Called {}{}{} with args {} and kwargs {}".format(className, func.__name__,
-                                                                                    caller, args, kwargs))
-
+      logging.log(self.logLevel, "Called {}{}{} with args {} and kwargs {}".format(className, func.__name__,
+                                                                                   caller, args, kwargs))
       return func(*args, **kwargs)
-    return wrapper
-  return decorator
+    return wrapped_f
 
 
 def onExceptionReturnNone(func):
@@ -100,16 +104,19 @@ class MultiMethodRegistrations(object):
 
   registry = {}
 
+
 class MultiMethod(object):
   # source: http://www.artima.com/weblogs/viewpost.jsp?thread=101605
   def __init__(self, name):
+    self.__name__ = name
     self.name = name
     self.typemap = {}
-  def __call__(self, *args):
+
+  def __call__(self, *args, **kwargs):
     types = tuple(arg.__class__ for arg in args) # a generator expression!
     function = self.typemap.get(types)
     if function is None:
-      raise TypeError("no match")
+      raise TypeError("no match for types %s" % str(types))
     return function(*args)
   def register(self, types, function):
     if types in self.typemap:
@@ -118,12 +125,31 @@ class MultiMethod(object):
 
 
 def multimethod(*types):
-  # source: http://www.artima.com/weblogs/viewpost.jsp?thread=101605
-  def register(function):
-    name = function.__name__
+  """ This decorator can be used to define different versions of a
+      method/function for different datatypes but keeping the same name
+
+      original source: http://www.artima.com/weblogs/viewpost.jsp?thread=101605
+
+      @multimethod([int, float], [int, float], str)
+      def foo(arg1, arg2, arg3):
+        print arg1, arg2, arg3
+
+      @multimethod([int, float], str)
+      def foo(arg1, arg2, arg3):
+        print arg1, arg2, arg3
+
+      foo(1,2,"bar")
+      foo(1.0,2,"bar")
+      foo(1,2.0,"bar")
+      foo(1.0,2.0,"bar")
+  """
+
+  def register(func):
+    name = func.__name__
     mm = MultiMethodRegistrations.registry.get(name)
     if mm is None:
       mm = MultiMethodRegistrations.registry[name] = MultiMethod(name)
-    mm.register(types, function)
+    for combination in list(itertools.product(*[[t] if type(t) is not list else t for t in types], repeat=1)):
+      mm.register(combination, func)
     return mm
   return register

--- a/SlicerProstate/SlicerProstateUtils/mixins.py
+++ b/SlicerProstate/SlicerProstateUtils/mixins.py
@@ -340,24 +340,39 @@ class ModuleLogicMixin(GeneralModuleMixin):
     label.SetAndObserveImageData(dilateErode.GetOutput())
 
   @staticmethod
-  def getCentroidForLabel(label, value):
-    ls = sitk.LabelShapeStatisticsImageFilter()
-    dstLabelAddress = sitkUtils.GetSlicerITKReadWriteAddress(label.GetName())
-    try:
-      dstLabelImage = sitk.ReadImage(dstLabelAddress)
-    except RuntimeError as exc:
-      return None
-    ls.Execute(dstLabelImage)
-    centroid = ls.GetCentroid(value)
-    IJKtoRAS = vtk.vtkMatrix4x4()
-    label.GetIJKToRASMatrix(IJKtoRAS)
-    order = label.ComputeScanOrderFromIJKToRAS(IJKtoRAS)
-    if order == 'IS':
-      centroid = [-centroid[0], -centroid[1], centroid[2]]
-    elif order == 'AP':
-      centroid = [-centroid[0], -centroid[2], -centroid[1]]
-    elif order == 'LR':
-      centroid = [centroid[0], -centroid[2], -centroid[1]]
+  @multimethod(slicer.vtkMRMLLabelMapVolumeNode, [int])
+  def getCentroidForLabel(labelNode, value):
+    labelAddress = sitkUtils.GetSlicerITKReadWriteAddress(labelNode.GetName())
+    labelImage = sitk.ReadImage(labelAddress)
+
+    ls = sitk.LabelStatisticsImageFilter()
+    ls.Execute(labelImage, labelImage)
+    bb = ls.GetBoundingBox(value)
+
+    centroid = None # sagittal, coronal, axial
+    if len(bb) > 0:
+      centerIJK = [((bb[0] + bb[1]) / 2), ((bb[2] + bb[3]) / 2), ((bb[4] + bb[5]) / 2)]
+      logging.debug('BB is: ' + str(bb))
+      logging.debug('i_center = '+str(centerIJK[0]))
+      logging.debug('j_center = '+str(centerIJK[1]))
+      logging.debug('k_center = '+str(centerIJK[2]))
+
+      IJKtoRAS = vtk.vtkMatrix4x4()
+      labelNode.GetIJKToRASMatrix(IJKtoRAS)
+      IJKtoRASDir = vtk.vtkMatrix4x4()
+      labelNode.GetIJKToRASDirectionMatrix(IJKtoRASDir)
+      RAScoord = IJKtoRAS.MultiplyPoint((centerIJK[0], centerIJK[1], centerIJK[2], 1))
+
+      order = labelNode.ComputeScanOrderFromIJKToRAS(IJKtoRAS)
+      if order == 'IS':
+        RASDir = IJKtoRASDir.MultiplyPoint((RAScoord[0], RAScoord[1], RAScoord[2], 1))
+        centroid = [-RASDir[0], -RASDir[1], RASDir[2]]
+      elif order == 'AP':
+        RASDir = IJKtoRASDir.MultiplyPoint((RAScoord[0], RAScoord[1], RAScoord[2], 1))
+        centroid = [-RASDir[0], -RASDir[2], -RASDir[1]]
+      elif order == 'LR':
+        RASDir = IJKtoRASDir.MultiplyPoint((RAScoord[2], RAScoord[1], RAScoord[0], 1))
+        centroid = [RASDir[0], -RASDir[2], -RASDir[1]]
     return centroid
 
   @staticmethod

--- a/SlicerProstate/SlicerProstateUtils/mixins.py
+++ b/SlicerProstate/SlicerProstateUtils/mixins.py
@@ -399,32 +399,33 @@ class ModuleLogicMixin(GeneralModuleMixin):
         return ""
 
   @staticmethod
-  @multimethod(str, str)
+  @multimethod([str, unicode], [str, unicode])
   def getDICOMValue(currentFile, tag):
     return ModuleLogicMixin.getDICOMValue(currentFile, tag, "")
 
   @staticmethod
-  @multimethod(str, str, str)
+  @multimethod([str, unicode], [str, unicode], [str, unicode])
   def getDICOMValue(currentFile, tag, default):
     try:
       return slicer.dicomDatabase.fileValue(currentFile, tag)
     except RuntimeError:
       logging.info("There are problems with accessing DICOM value %s from file %s" % (tag, currentFile))
-      return None if default == "" else default
+    return default
 
   @staticmethod
-  @multimethod(slicer.vtkMRMLScalarVolumeNode, str)
+  @multimethod(slicer.vtkMRMLScalarVolumeNode, [str, unicode])
   def getDICOMValue(volumeNode, tag):
     return ModuleLogicMixin.getDICOMValue(volumeNode, tag, "")
 
   @staticmethod
-  @multimethod(slicer.vtkMRMLScalarVolumeNode, str, str)
+  @multimethod(slicer.vtkMRMLScalarVolumeNode, [str, unicode], [str, unicode])
   def getDICOMValue(volumeNode, tag, default):
     try:
       currentFile = volumeNode.GetStorageNode().GetFileName()
       return ModuleLogicMixin.getDICOMValue(currentFile, tag, default)
     except (RuntimeError, AttributeError):
-      return None if default == "" else default
+      logging.info("There are problems with accessing DICOM value %s from volume node %s" % (tag, volumeNode.GetID()))
+    return default
 
   @staticmethod
   def getFileList(directory):


### PR DESCRIPTION
- added new decorator (multimethod) for providing different versions of a method/function:
  - it also can help restricting parameter types delivered to a method/function
- moved code for computing centroid from mpReview to SlicerProstate. Can be reused in:
  - mpReview
  - SliceTracker (centering FOV to prostate label)
  - Reporting (centering to label on segmentation selection)
