### PR TITLE
Renamed methods of ParameterNodeObservationMixin for preventing method name conflicts

### DIFF
--- a/SlicerProstate/CMakeLists.txt
+++ b/SlicerProstate/CMakeLists.txt
@@ -9,6 +9,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}Utils/helpers.py
   ${MODULE_NAME}Utils/constants.py
   ${MODULE_NAME}Utils/decorators.py
+  ${MODULE_NAME}Utils/signal.py
   ${MODULE_NAME}Utils/events.py
   ${MODULE_NAME}Utils/widgets.py
   ${MODULE_NAME}Utils/buttons.py

--- a/SlicerProstate/SlicerProstateUtils/helpers.py
+++ b/SlicerProstate/SlicerProstateUtils/helpers.py
@@ -904,7 +904,7 @@ class DICOMBasedInformationWatchBox(FileBasedInformationWatchBox):
     return ""
 
 
-class TargetCreationWidget(ModuleWidgetMixin, ParameterNodeObservationMixin):
+class TargetCreationWidget(ModuleWidgetMixin):
 
   HEADERS = ["Name","Delete"]
   MODIFIED_EVENT = "ModifiedEvent"

--- a/SlicerProstate/SlicerProstateUtils/helpers.py
+++ b/SlicerProstate/SlicerProstateUtils/helpers.py
@@ -24,13 +24,13 @@ class SampleDataDownloader(FancyURLopener, ParameterNodeObservationMixin):
     self.wasCanceled = False
     if self.isDownloading:
       self.cancelDownload()
-    self.removeObservers()
+    self.removeEventObservers()
     if self.loggingEnabled:
       self._addOwnObservers()
 
   def _addOwnObservers(self):
     for event in self.EVENTS.values():
-      self.addObserver(event, self.logMessage)
+      self.addEventObserver(event, self.logMessage)
 
   def __del__(self):
     super(SampleDataDownloader, self).__del__()
@@ -525,13 +525,13 @@ class IncomingDataWindow(qt.QWidget, ModuleWidgetMixin, ParameterNodeObservation
     self.cancelButtonText = cancelText
     self.setup()
     self.dicomReceiver = SmartDICOMReceiver(incomingDataDirectory=incomingDataDirectory)
-    self.dicomReceiver.addObserver(SlicerProstateEvents.StatusChangedEvent, self.onStatusChanged)
-    self.dicomReceiver.addObserver(SlicerProstateEvents.IncomingDataReceiveFinishedEvent, self.onReceiveFinished)
+    self.dicomReceiver.addEventObserver(SlicerProstateEvents.StatusChangedEvent, self.onStatusChanged)
+    self.dicomReceiver.addEventObserver(SlicerProstateEvents.IncomingDataReceiveFinishedEvent, self.onReceiveFinished)
 
   def __del__(self):
     super(IncomingDataWindow, self).__del__()
     if self.dicomReceiver:
-      self.dicomReceiver.removeObservers()
+      self.dicomReceiver.removeEventObservers()
 
   @vtk.calldata_type(vtk.VTK_STRING)
   def onStatusChanged(self, caller, event, callData):

--- a/SlicerProstate/SlicerProstateUtils/mixins.py
+++ b/SlicerProstate/SlicerProstateUtils/mixins.py
@@ -106,6 +106,26 @@ class ModuleWidgetMixin(GeneralModuleMixin):
       pass
     return path
 
+  def createSliceWidgetClassMembers(self, name):
+    widget = self.layoutManager.sliceWidget(name)
+    setattr(self, name.lower()+"Widget", widget)
+    setattr(self, name.lower()+"CompositeNode", widget.mrmlSliceCompositeNode())
+    setattr(self, name.lower()+"SliceView", widget.sliceView())
+    setattr(self, name.lower()+"SliceViewInteractor", widget.sliceView().interactorStyle().GetInteractor())
+    logic = widget.sliceLogic()
+    setattr(self, name.lower()+"SliceLogic", logic)
+    setattr(self, name.lower()+"SliceNode", logic.GetSliceNode())
+
+  def getAllVisibleWidgets(self):
+    visibleWidgets = []
+    sliceLogics = self.layoutManager.mrmlSliceLogics()
+    for n in range(sliceLogics.GetNumberOfItems()):
+      sliceLogic = sliceLogics.GetItemAsObject(n)
+      widget = self.layoutManager.sliceWidget(sliceLogic.GetName())
+      if widget.sliceView().visible:
+        visibleWidgets.append(widget)
+    return visibleWidgets
+
   def getOrCreateCustomProgressBar(self):
     for child in slicer.util.mainWindow().statusBar().children():
       if isinstance(child, CustomStatusProgressbar):
@@ -313,6 +333,12 @@ class ModuleLogicMixin(GeneralModuleMixin):
     timer.timeout.connect(slot)
     timer.setSingleShot(singleShot)
     return timer
+
+  @staticmethod
+  def getTargetPosition(targetNode, index):
+    position = [0.0, 0.0, 0.0]
+    targetNode.GetNthFiducialPosition(index, position)
+    return position
 
   @staticmethod
   def get3DDistance(p1, p2):

--- a/SlicerProstate/SlicerProstateUtils/mixins.py
+++ b/SlicerProstate/SlicerProstateUtils/mixins.py
@@ -17,49 +17,49 @@ class ParameterNodeObservationMixin(object):
 
   @logmethod(logging.DEBUG)
   def __del__(self):
-    self.removeObservers()
+    self.removeEventObservers()
 
   @property
   def parameterNode(self):
     try:
       return self._parameterNode
     except AttributeError:
-      self._parameterNode = self.getParameterNode() if hasattr(self, "getParameterNode") else self._getParameterNode()
+      self._parameterNode = self.getParameterNode() if hasattr(self, "getParameterNode") else self._createParameterNode()
     return self._parameterNode
 
   @property
-  def parameterNodeObservations(self):
+  def parameterNodeObservers(self):
     try:
-      return self._parameterNodeObservations
+      return self._parameterNodeObservers
     except AttributeError:
-      self._parameterNodeObservations = []
-    return self._parameterNodeObservations
+      self._parameterNodeObservers = []
+    return self._parameterNodeObservers
 
-  def _getParameterNode(self):
+  def _createParameterNode(self):
     parameterNode = slicer.vtkMRMLScriptedModuleNode()
     slicer.mrmlScene.AddNode(parameterNode)
     return parameterNode
 
-  def removeObservers(self, method=None):
-    for e, m, g, t in list(self.parameterNodeObservations):
+  def removeEventObservers(self, method=None):
+    for e, m, g, t in list(self.parameterNodeObservers):
       if method == m or method is None:
         self.parameterNode.RemoveObserver(t)
-        self.parameterNodeObservations.remove([e, m, g, t])
+        self.parameterNodeObservers.remove([e, m, g, t])
 
-  def addObserver(self, event, method, group='none'):
-    if self.hasObserver(event, method):
-      self.removeObserver(event, method)
+  def addEventObserver(self, event, method, group='none'):
+    if self.hasEventObserver(event, method):
+      self.removeEventObserver(event, method)
     tag = self.parameterNode.AddObserver(event, method)
-    self.parameterNodeObservations.append([event, method, group, tag])
+    self.parameterNodeObservers.append([event, method, group, tag])
 
-  def removeObserver(self, event, method):
-    for e, m, g, t in self.parameterNodeObservations:
+  def removeEventObserver(self, event, method):
+    for e, m, g, t in self.parameterNodeObservers:
       if e == event and m == method:
         self.parameterNode.RemoveObserver(t)
-        self.parameterNodeObservations.remove([e, m, g, t])
+        self.parameterNodeObservers.remove([e, m, g, t])
 
-  def hasObserver(self, event, method):
-    for e, m, g, t in self.parameterNodeObservations:
+  def hasEventObserver(self, event, method):
+    for e, m, g, t in self.parameterNodeObservers:
       if e == event and m == method:
         return True
     return False
@@ -70,9 +70,9 @@ class ParameterNodeObservationMixin(object):
     else:
       self.parameterNode.InvokeEvent(event)
 
-  def getObservers(self):
+  def getEventObservers(self):
     observerMethodDict = {}
-    for e, m, g, t in self.parameterNodeObservations:
+    for e, m, g, t in self.parameterNodeObservers:
       observerMethodDict[e] = m
     return observerMethodDict
 

--- a/SlicerProstate/SlicerProstateUtils/signal.py
+++ b/SlicerProstate/SlicerProstateUtils/signal.py
@@ -18,10 +18,10 @@
           self.myClassInstance.processingFinished.connect(self.onProcessingFinished)
 
         def onProcessingFinished(self):
-          print "Caught in Class: Processing is done!"
+          print "Slot in class: Signal successfully caught. Processing is done!"
 
       def slot():
-        print "Processing is done!"
+        print "Signal successfully caught. Processing is done!"
 
 
       myClassInstance = MyClass()
@@ -47,7 +47,7 @@ class Signal(object):
     self.slots = []
 
   def __del__(self):
-    self.slots = {}
+    self.slots = []
 
   def __call__(self, *args, **kwargs):
     for slot in self.slots:

--- a/SlicerProstate/SlicerProstateUtils/signal.py
+++ b/SlicerProstate/SlicerProstateUtils/signal.py
@@ -1,0 +1,73 @@
+""" This decorator can be used for creating signals and connecting slots to them. You could compare it to qt signals.
+    
+    Usage:
+    
+      class MyClass(SignalProviderBase):
+        @signal
+        def processingFinished(self):
+          pass
+
+        def __init__(self):
+          SignalProviderBase.__init__(self)
+
+
+      class MyListeningClass(object):
+
+        def __init__(self):
+          self.myClassInstance = MyClass()
+          self.myClassInstance.processingFinished.connect(self.onProcessingFinished)
+
+        def onProcessingFinished(self):
+          print "Caught in Class: Processing is done!"
+
+      def slot():
+        print "Processing is done!"
+
+
+      myClassInstance = MyClass()
+      myClassInstance.processingFinished.connect(slot)
+
+      myClassInstance.processingFinished()
+
+      myListeningClass = MyListeningClass()
+      myListeningClass.myClassInstance.processingFinished()
+
+"""
+
+
+def signal(func):
+  func.isSignal = True
+  return func
+
+
+class Signal(object):
+
+  def __init__(self, func):
+    self.func = func
+    self.slots = []
+
+  def __del__(self):
+    self.slots = {}
+
+  def __call__(self, *args, **kwargs):
+    for slot in self.slots:
+      slot(*args[1:])
+    return self.func(*args[1:], **kwargs)
+
+  def connect(self, slot):
+    if slot not in self.slots:
+      self.slots.append(slot)
+
+  def disconnect(self, slot):
+    if slot in self.slots:
+      self.slots.remove(slot)
+
+
+class SignalProviderBase(object):
+
+  def __getAllMethods(self):
+    return [getattr(self, method) for method in dir(self) if callable(getattr(self, method))]
+
+  def __init__(self):
+    for signal in [method for method in self.__getAllMethods() if hasattr(method, "isSignal")]:
+      setattr(self, signal.__name__, Signal(signal))


### PR DESCRIPTION
- added new signal decorator/class/base class so that class can decorate methods as signals which can be called by that class and execute slots that are connected to that signal (approach is pretty similar to qt)

fixes #37 
