### PR TITLE
BUG: Setting ActiveListID to None in markupsLogic causes Slicer to crash

### DIFF
--- a/SlicerProstate/SlicerProstateUtils/helpers.py
+++ b/SlicerProstate/SlicerProstateUtils/helpers.py
@@ -922,10 +922,10 @@ class TargetCreationWidget(ModuleWidgetMixin):
     if node:
       self.placeWidget.setCurrentNode(node)
       self.addTargetListObservers()
+      self.markupsLogic.SetActiveListID(node)
     else:
       selectionNode = slicer.mrmlScene.GetNodeByID("vtkMRMLSelectionNodeSingleton")
       selectionNode.SetReferenceActivePlaceNodeID(None)
-    self.markupsLogic.SetActiveListID(node)
     self.updateTable()
 
   def __init__(self, parent):


### PR DESCRIPTION
fixes https://github.com/SlicerProstate/SliceTracker/issues/231