### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(SlicerProstate)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerProstate")
-set(EXTENSION_CATEGORY "Applications")
-set(EXTENSION_CONTRIBUTORS "Andrey Fedorov (Brigham and Women's Hospital), Andras Lasso (Queen's University)")
+set(EXTENSION_HOMEPAGE "https://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/SlicerProstate")
+set(EXTENSION_CATEGORY "Informatics")
+set(EXTENSION_CONTRIBUTORS "Andrey Fedorov (Brigham and Women's Hospital), Andras Lasso (Queen's University), Alireza Mehrtash (Brigham and Women's Hospital)")
 set(EXTENSION_DESCRIPTION "SlicerProstate extension hosts various modules to facilitate processing and management of prostate image data, utilizing prostate images in image-guided interventions and development of the imaging biomarkers of the prostate cancer.")
-set(EXTENSION_ICONURL "http://wiki.slicer.org/slicerWiki/images/8/87/SlicerProstate_Logo_1.0_128x128.png")
-set(EXTENSION_SCREENSHOTURLS "http://wiki.slicer.org/slicerWiki/images/f/ff/DistanceMapBasedRegistration_example1.png http://wiki.slicer.org/slicerWiki/images/3/36/SegmentationSmoothing_example1.png http://wiki.slicer.org/slicerWiki/images/c/c3/QuadEdgeSurfaceMesher_example1.png")
+set(EXTENSION_ICONURL "https://wiki.slicer.org/slicerWiki/images/8/87/SlicerProstate_Logo_1.0_128x128.png")
+set(EXTENSION_SCREENSHOTURLS "https://wiki.slicer.org/slicerWiki/images/f/ff/DistanceMapBasedRegistration_example1.png https://wiki.slicer.org/slicerWiki/images/3/36/SegmentationSmoothing_example1.png https://wiki.slicer.org/slicerWiki/images/c/c3/QuadEdgeSurfaceMesher_example1.png")
 
 #-----------------------------------------------------------------------------
 # Extension dependencies


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.