### PR TITLE
COMP: Include vnl_levenberg_marquardt.h for ITK 6 compatibility

### DIFF
--- a/DWModeling/DWModeling.cxx
+++ b/DWModeling/DWModeling.cxx
@@ -2,6 +2,7 @@
 #include "itkImageDuplicator.h"
 #include "itkMetaDataObject.h"
 #include "itkLevenbergMarquardtOptimizer.h"
+#include <vnl/algo/vnl_levenberg_marquardt.h>
 #include "itkArray.h"
 
 

--- a/DWModeling/DWModeling.cxx
+++ b/DWModeling/DWModeling.cxx
@@ -754,7 +754,6 @@ int main( int argc, char * argv[])
   for(vvIt.GoToBegin();!vvIt.IsAtEnd();++vvIt){
     //if(cnt>10)
     //  break;
-    VectorVolumeType::IndexType index = vvIt.GetIndex();
     VectorVolumeType::PixelType vectorVoxel = vvIt.Get();
     VectorVolumeType::PixelType fittedVoxel(vectorVoxel.GetSize());
     for(int i=0;i<fittedVoxel.GetSize();i++)


### PR DESCRIPTION
`DWModeling` fails to compile against ITK 6: `LevenbergMarquardtOptimizer::InternalOptimizerType` is an incomplete type. One added include fixes it, and one unused declaration is dropped so the file also builds with `ITK_FUTURE_LEGACY_REMOVE=ON`. Verified compiling against **ITK 5.4.7, ITK 6.0.0 main, and ITK 6.0.0 main with `ITK_FUTURE_LEGACY_REMOVE=ON`**.

<details>
<summary>Root cause — incomplete InternalOptimizerType (commit 1)</summary>

ITK main changed `itkLevenbergMarquardtOptimizer.h` to forward-declare rather than include the VNL type, while still exporting the alias:

```cpp
class vnl_levenberg_marquardt;                          // main
using InternalOptimizerType = vnl_levenberg_marquardt;
```

ITK 5.4 had `#include "vnl/algo/vnl_levenberg_marquardt.h"` in that header. The ITK header still compiles either way — the type is merely *incomplete* at any downstream call site that touches a member, which is why the error surfaces here and not in ITK:

```
DWModeling.cxx:787:19: error: member access into incomplete type
  'LevenbergMarquardtOptimizer::InternalOptimizerType'
  vnlOptimizer->set_f_tolerance(1e-4f);
```

`DWModeling.cxx` is the only file in the repository that touches `GetOptimizer()` / `InternalOptimizerType`.
</details>

<details>
<summary>Root cause — GetIndex() under ITK_FUTURE_LEGACY_REMOVE (commit 2)</summary>

`ImageRegionConstIterator::GetIndex()` is scheduled for removal, so building against ITK main with `ITK_FUTURE_LEGACY_REMOVE=ON` fails:

```
DWModeling.cxx:757:46: error: no member named 'GetIndex' in
  'itk::ImageRegionConstIterator<itk::VectorImage<float>>'
```

The index it initialized is never read — `grep -n '\bindex\b' DWModeling/DWModeling.cxx` returns only the declaration — so it is dropped rather than switching to an index-carrying iterator. `itkImageRegionConstIteratorWithIndex.h` is already included in this file, but that iterator maintains index state per step, which would be a real per-voxel cost to populate a value nothing consumes. No behaviour change; also silences a latent `-Wunused-variable`.
</details>

<details>
<summary>Verification</summary>

Compiled in a downstream forest testbed that builds Slicer plus the full ExtensionsIndex against a chosen ITK ref, on macOS arm64. Each configuration compiled the same post-fix source using that build tree's own command from `compile_commands.json`:

| Configuration | before | after |
|---|---|---|
| ITK 5.4.7 | pass | `rc=0`, 0 errors |
| ITK 6.0.0 `main` | BUILD-FAIL (incomplete type) | `rc=0`, 0 errors |
| ITK 6.0.0 `main` + `ITK_FUTURE_LEGACY_REMOVE` | BUILD-FAIL (`GetIndex`) | `rc=0`, 0 errors |

Two caveats stated plainly:

- These compile against Slicer's vendored ITK (`main` plus its customizable-namespace patch), because that is what the extension actually builds against. Same ITK source.
- This is a compile check. `ITK_FUTURE_LEGACY_REMOVE` was supplied as a compile definition; both trees' `itkConfigure.h` carry it as a commented `#undef`, so nothing overrides it, and it demonstrably took effect — it is what produced the `GetIndex` error. An ITK rebuilt with the CMake option would additionally drop symbols, which is a link-time concern not covered here.

Note: merged PR #59 was a different ITK 6 fix touching this same file (adding semicolons after `itkGenericExceptionMacro`); it does not address either error.
</details>

<!--
provenance: forest build testbed, sweeps 2026-08-21 and 2026-08-22, macOS arm64
itk6_ref: fee22c1e22 (6.0.0 main) ; itk5_ref: release-5.4 forest ; earlier sweep used 9f127d9231 / 7fefad582b
fix_1: DWModeling.cxx include vnl/algo/vnl_levenberg_marquardt.h (incomplete InternalOptimizerType)
fix_2: DWModeling.cxx:757 drop unused IndexType index = vvIt.GetIndex() (ITK_FUTURE_LEGACY_REMOVE)
class_of_bug: ITK6 include-pruning + future-legacy API removal
verification_method: -fsyntax-only using each build tree's compile_commands.json entry
sibling_extensions_same_bug: DSCMRIAnalysis (QIICR/DSC_Analysis), T1Mapping (QIICR/T1Mapping) -- both upstreams archived
-->
